### PR TITLE
Fix iOS camera flow by removing save-to-device step

### DIFF
--- a/components/receipt-processor.tsx
+++ b/components/receipt-processor.tsx
@@ -14,62 +14,6 @@ interface ReceiptProcessorProps {
   variant?: "button" | "dropzone"
 }
 
-/** Best-effort save so the user keeps a copy (Downloads / save dialog / share). */
-async function saveImageToDevice(file: File): Promise<void> {
-  const baseName = `receipt-${Date.now()}`
-  const ext =
-    file.name.split(".").pop()?.toLowerCase() ||
-    (file.type.includes("png") ? "png" : "jpg")
-
-  try {
-    if (typeof window !== "undefined" && "showSaveFilePicker" in window) {
-      const picker = window as Window & {
-        showSaveFilePicker: (opts: {
-          suggestedName: string
-          types?: { description: string; accept: Record<string, string[]> }[]
-        }) => Promise<FileSystemFileHandle>
-      }
-      const handle = await picker.showSaveFilePicker({
-        suggestedName: `${baseName}.${ext}`,
-        types: [
-          {
-            description: "Image",
-            accept: { "image/*": [".jpg", ".jpeg", ".png", ".webp", ".heic"] },
-          },
-        ],
-      })
-      const writable = await handle.createWritable()
-      await writable.write(await file.arrayBuffer())
-      await writable.close()
-      return
-    }
-  } catch {
-    // User cancelled or API unavailable
-  }
-
-  try {
-    if (navigator.canShare && navigator.canShare({ files: [file] })) {
-      await navigator.share({
-        files: [file],
-        title: "Receipt photo",
-      })
-      return
-    }
-  } catch {
-    // Share cancelled or failed
-  }
-
-  const url = URL.createObjectURL(file)
-  const a = document.createElement("a")
-  a.href = url
-  a.download = `${baseName}.${ext}`
-  a.rel = "noopener"
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
-
 export default function ReceiptProcessor({
   onReceiptProcessed,
   isDialogOpen,
@@ -87,18 +31,11 @@ export default function ReceiptProcessor({
 
   useEffect(() => {
     const handleFileSelect = async (event: Event) => {
-      const customEvent = event as CustomEvent<{ file: File; fromCamera?: boolean }>
+      const customEvent = event as CustomEvent<{ file: File }>
       if (!customEvent.detail?.file) return
 
       onProcessingChange(true)
       const file = customEvent.detail.file
-      const fromCamera = customEvent.detail.fromCamera === true
-
-      if (fromCamera) {
-        void saveImageToDevice(file).catch(() => {
-          /* non-fatal */
-        })
-      }
 
       try {
         const formData = new FormData()
@@ -144,9 +81,9 @@ export default function ReceiptProcessor({
     }
   }, [onReceiptProcessed, toast, onDialogChange, onProcessingChange])
 
-  const dispatchFile = (file: File, fromCamera: boolean) => {
+  const dispatchFile = (file: File) => {
     const event = new CustomEvent("receiptFileSelected", {
-      detail: { file, fromCamera },
+      detail: { file },
     })
     document.dispatchEvent(event)
   }
@@ -154,7 +91,7 @@ export default function ReceiptProcessor({
   const handleLibraryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
-      dispatchFile(file, false)
+      dispatchFile(file)
     }
     e.target.value = ""
   }
@@ -162,7 +99,7 @@ export default function ReceiptProcessor({
   const handleCameraChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
-      dispatchFile(file, true)
+      dispatchFile(file)
     }
     e.target.value = ""
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On iOS, taking a receipt photo via the camera did not proceed to Veryfi API processing. The save-to-device step (triggered via `navigator.share` on iOS Safari) conflicted with the camera flow and blocked progression to the next step.

On Android, this worked because image saving appeared to run in the background without interrupting the flow.

## Solution

Remove the save-to-device behavior for camera captures in `components/receipt-processor.tsx`. Camera photos now go directly to Veryfi processing, matching the library upload path.

## Changes

- Removed `saveImageToDevice` helper (File System Access API, `navigator.share`, and download fallback)
- Removed camera-only save call before Veryfi API request
- Simplified `dispatchFile` by removing the unused `fromCamera` flag

## Testing

- [ ] On iOS Safari/PWA: tap Camera, take a photo, confirm receipt processing completes and advances to the next step
- [ ] On Android: confirm camera flow still works
- [ ] Library upload path unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c41-15ef-7d84-8f3e-2033000bc489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c41-15ef-7d84-8f3e-2033000bc489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

